### PR TITLE
Generate Shapes task

### DIFF
--- a/docs/source/api/impuls.tasks.generate_shapes.rst
+++ b/docs/source/api/impuls.tasks.generate_shapes.rst
@@ -1,0 +1,9 @@
+﻿impuls.tasks.generate\_shapes
+==============================
+
+.. automodule:: impuls.tasks.generate_shapes
+    :exclude-members: GenerateShapes
+
+    .. class:: GenerateShapes
+
+        See :py:class:`impuls.tasks.GenerateShapes`.

--- a/docs/source/api/impuls.tasks.rst
+++ b/docs/source/api/impuls.tasks.rst
@@ -2,3 +2,17 @@
 ============
 
 .. automodule:: impuls.tasks
+    :exclude-members: GenerateShapes
+
+.. autoclass:: GenerateShapes
+    :exclude-members: create_routing_graph, create_stop_snapper, create_leg_router, resolve_osm_profile
+
+    .. autoattribute:: routes
+
+    .. autoattribute:: id_prefix
+
+    .. autoattribute:: overwrite
+
+    .. autoattribute:: progress_report_step
+
+    .. autoattribute:: task_name

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -14,6 +14,7 @@ All of the following modules are accessible when importing the top-level package
     impuls.resource
     impuls.selector
     impuls.tasks
+    impuls.tasks.generate_shapes
     impuls.tasks.merge
     impuls.tasks.modify_from_csv
     impuls.tools.geo

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, Path(__file__).parents[2].resolve().as_posix())
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Impuls"
-copyright = "2024-2025, Mikołaj Kuranowski"
+copyright = "2024-2026, Mikołaj Kuranowski"
 author = "Mikołaj Kuranowski"
 
 # -- General configuration ---------------------------------------------------

--- a/impuls/tasks/__init__.py
+++ b/impuls/tasks/__init__.py
@@ -6,6 +6,7 @@ from .add_entity import AddEntity
 from .assign_directions import AssignDirections
 from .exec_sql import ExecuteSQL
 from .extend_calendars import ExtendCalendars, ExtendCalendarsFromPolishExceptions
+from .generate_shapes import GenerateShapes
 from .generate_trip_headsign import GenerateTripHeadsign
 from .load_busman import LoadBusManMDB
 from .load_db import LoadDB
@@ -24,6 +25,7 @@ __all__ = [
     "ExecuteSQL",
     "ExtendCalendars",
     "ExtendCalendarsFromPolishExceptions",
+    "GenerateShapes",
     "GenerateTripHeadsign",
     "LoadBusManMDB",
     "LoadDB",

--- a/impuls/tasks/generate_shapes.py
+++ b/impuls/tasks/generate_shapes.py
@@ -1,0 +1,1086 @@
+# © Copyright 2026 Mikołaj Kuranowski
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import logging
+import shutil
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import InitVar, dataclass, field
+from itertools import pairwise
+from math import isfinite
+from pathlib import Path
+from typing import Any, Generic, Self, TypeAlias, TypeVar, cast
+
+import routx
+from typing_extensions import dataclass_transform
+
+from .. import selector
+from ..db import DBConnection
+from ..model import Route
+from ..task import Task, TaskRuntime
+from ..tools.geo import earth_distance_m
+from ..tools.types import StrPath
+
+StopKey: TypeAlias = tuple[str, int]
+"""
+Unique identifier of a stop within a trip - a :py:attr:`stop_id <impuls.model.Stop.id>` and
+:py:attr:`stop_sequence <impuls.model.StopTime.stop_sequence>` pair.
+"""
+
+ShapeKey: TypeAlias = tuple[StopKey, ...]
+"""Unique identifier of a shape - a variable-length tuple of :py:class:`stop keys <StopKey>`."""
+
+ShapePoint: TypeAlias = tuple[float, float, float]
+"""Point in a shape - a latitude, longitude and cumulative distance."""
+
+
+@dataclass
+class Waypoint:
+    """Intermediary point used when generating a shape, usually corresponding to a stop."""
+
+    id: StopKey | str
+    """
+    ID of the waypoint - either a :py:class:`stop <StopKey>`,
+    or some arbitrary point described by a unique string, different to all stop ids.
+
+    Both :py:attr:`StopKey.id` or arbitrary strings here can be used as
+    cache keys in the same lookup table.
+    """
+
+    lat: float
+    """Geographic latitude of the waypoint."""
+
+    lon: float
+    """Geographic longitude of the waypoint."""
+
+    node: int = 0
+    """
+    Identifier of a node in a routing graph corresponding to this waypoint,
+    or `0` when no appropriate node was found.
+    """
+
+    def cache_key(self) -> str:
+        return self.id if isinstance(self.id, str) else self.id[0]
+
+
+@dataclass
+class LegContext:
+    """
+    All data necessary when generating a shape's leg between two
+    :py:class:`waypoints <Waypoint>`.
+    """
+
+    start: Waypoint
+    """Beginning of the leg."""
+
+    end: Waypoint
+    """End of the leg."""
+
+
+@dataclass
+class GeneratedShape:
+    """Full shape, generated for a :py:class:`ShapeKey`."""
+
+    points: list[ShapePoint] = field(default_factory=list[ShapePoint])
+    """All :py:class:`points <ShapePoint>` of this shape."""
+
+    distances: dict[int, float] = field(default_factory=dict[int, float])
+    """
+    Mapping from :py:attr:`stop_sequence <impuls.model.StopTime.stop_sequence>`
+    to a cumulative distance along a shape to that stop.
+    """
+
+    def append_leg(self, ctx: LegContext, points: Iterable[ShapePoint]) -> None:
+        """Adds a leg to this generated shape."""
+
+        # If this is the very first leg, add the total distance to the very first stop
+        if not self.points:
+            if isinstance(ctx.start.id, tuple):
+                self.distances[ctx.start.id[1]] = 0.0
+            distance_offset = 0.0
+        else:
+            distance_offset = self.points[-1][2]
+
+        # Unless this is the very first leg, don't copy the first point.
+        # It'll be the same as the previous leg's last point, as that's a
+        # node snapped to the same stop
+        points_iter = iter(points)
+        if self.points:
+            next(points_iter, None)
+
+        self.points.extend((lat, lon, distance_offset + dist) for (lat, lon, dist) in points_iter)
+
+        if isinstance(ctx.end.id, tuple):
+            self.distances[ctx.end.id[1]] = self.points[-1][2]
+
+    def round(self, coord_precision: int = 6, dist_precision: int | None = 3) -> None:
+        """Rounds all stored coordinates and distances to the provided number of decimal places."""
+        dist_precision = coord_precision if dist_precision is None else dist_precision
+
+        self.points = [
+            (round(lat, coord_precision), round(lon, coord_precision), round(dist, dist_precision))
+            for (lat, lon, dist) in self.points
+        ]
+        self.distances = {seq: round(dist, dist_precision) for seq, dist in self.distances.items()}
+
+
+class LegRouter(ABC):
+    """
+    Abstract base class (interface) for a router - an object generating routes
+    between :py:class:`two points <LegContext>`.
+    """
+
+    @abstractmethod
+    def generate_leg(self, ctx: LegContext) -> Sequence[ShapePoint]:
+        """
+        Generates the shape between the two points in the provided :py:class:`context <LegContext>`.
+
+        If it's not possible to reach end from start, or the route can't otherwise be generated
+        (and the issue is to be suppressed), returns an empty sequence (`[]`).
+
+        However, if the start and end were snapped to the same node, a sequence of length one
+        (representing that node) should be returned.
+
+        :py:class:`ShapeBuilder` ensures this method is not called with
+        any :py:attr:`nodes <Waypoint.node>` set to ``0``.
+        """
+        raise NotImplementedError
+
+
+class StopSnapper(ABC):
+    """
+    Abstract base class (interface) for a stop snapper - an object
+    matching stops with nodes in a routing graph.
+    """
+
+    @abstractmethod
+    def snap(self, pt: Waypoint) -> int:
+        """
+        Snaps a waypoint to a corresponding node in the routing graph, and returns that node's id.
+        If there is no matched node, returns 0.
+
+        This method should ignore any existing :py:attr:`Waypoint.node` and is **not** required
+        to set that attribute back.
+        """
+        raise NotImplementedError
+
+    def distance_limited(
+        self,
+        get_node_location: Callable[[int], tuple[float, float]],
+        max_distance_m: float = 500.0,
+    ) -> "DistanceLimitedStopSnapper":
+        """
+        Limits the maximum distance of waypoint-to-node matches
+        by wrapping this snapper in a :py:class:`DistanceLimitedStopSnapper`.
+        """
+        return DistanceLimitedStopSnapper(self, get_node_location, max_distance_m)
+
+    def cached(self) -> "CachedStopSnapper":
+        """
+        Caches all waypoint-to-node matches by wrapping this snapper
+        in a :py:class:`CachedStopSnapper`.
+        """
+        return CachedStopSnapper(self)
+
+
+class DistanceLimitedStopSnapper(StopSnapper):
+    """
+    A `decorator <https://en.wikipedia.org/wiki/Decorator_pattern>`_ :py:class:`StopSnapper`
+    limiting snapped nodes to a maximum distance.
+    """
+
+    snapper: StopSnapper
+    """Main :py:class:`StopSnapper`, doing the actual matching."""
+
+    get_node_location: Callable[[int], tuple[float, float]]
+    """Callback for retrieving the location of a node by its id."""
+
+    max_distance: float
+    """
+    Max allowed distance to a node to allow a match.
+    In meters, unless :py:meth:`distance` is overridden.
+    """
+
+    def __init__(
+        self,
+        snapper: StopSnapper,
+        get_node_location: Callable[[int], tuple[float, float]],
+        max_distance: float = 500.0,
+    ) -> None:
+        super().__init__()
+        self.snapper = snapper
+        self.get_node_location = get_node_location
+        self.max_distance = max_distance
+
+    def snap(self, pt: Waypoint) -> int:
+        id = self.snapper.snap(pt)
+        if id == 0:
+            return 0
+
+        node_lat, node_lon = self.get_node_location(id)
+        if self.distance(pt.lat, pt.lon, node_lat, node_lon) > self.max_distance:
+            return 0
+
+        return id
+
+    def distance(self, pt_lat: float, pt_lon: float, node_lat: float, node_lon: float) -> float:
+        """
+        Calculates the distance between two points, for comparing against :py:attr:`max_distance`.
+
+        Defaults to meters, as calculated by :py:func:`impuls.tools.geo.earth_distance_m`.
+        """
+        return earth_distance_m(pt_lat, pt_lon, node_lat, node_lon)
+
+    def distance_limited(
+        self,
+        get_node_location: Callable[[int], tuple[float, float]],
+        max_distance_m: float = 500,
+    ) -> Self:
+        """Modifies attributes of this distance-limiting decorator."""
+        self.get_node_location = get_node_location
+        self.max_distance = max_distance_m
+        return self
+
+
+class CachedStopSnapper(StopSnapper):
+    """
+    A `decorator <https://en.wikipedia.org/wiki/Decorator_pattern>`_ :py:class:`StopSnapper`
+    caching the results of matching.
+    """
+
+    snapper: StopSnapper
+    """Main :py:class:`StopSnapper`, doing the actual matching."""
+
+    cache: dict[str, int]
+    """Cache from a :py:class:`Waypoint` key to matched node."""
+
+    def __init__(self, snapper: StopSnapper) -> None:
+        super().__init__()
+        self.snapper = snapper
+        self.cache = {}
+
+    def snap(self, pt: Waypoint) -> int:
+        key = pt.cache_key()
+        if (node_id := self.cache.get(key)) is None:
+            node_id = self.snapper.snap(pt)
+            self.cache[key] = node_id
+        return node_id
+
+    def cached(self) -> Self:
+        """Returns this snapper unmodified."""
+        return self
+
+
+class ErrorObserver:
+    """
+    Base class for error observers - objects collecting information on errors encountered
+    during shape generation.
+
+    The default implementation does nothing.
+    """
+
+    def on_error(self, ctx: LegContext, error: Any, points: Sequence[ShapePoint]) -> None:
+        """Callback on an error."""
+
+
+class MultiErrorObserver(ErrorObserver):
+    """MultiErrorObserver is an :py:class:`ErrorObserver` delegating an error callback to
+    multiple other observers.
+    """
+
+    observers: tuple[ErrorObserver, ...]
+
+    def __init__(self, *observers: ErrorObserver) -> None:
+        self.observers = observers
+
+    def on_error(self, ctx: LegContext, error: Any, points: Sequence[ShapePoint]) -> None:
+        for observer in self.observers:
+            observer.on_error(ctx, error, points)
+
+
+class ErrorLogger(ErrorObserver):
+    """:py:class:`ErrorObserver` implementation which logs all errors as warnings."""
+
+    logger: logging.Logger
+
+    def __init__(self, logger: logging.Logger | None) -> None:
+        self.logger = logger or logging.getLogger("Task.GenerateShapes")
+
+    def on_error(self, ctx: LegContext, error: Any, points: Sequence[ShapePoint]) -> None:
+        self.logger.warning(
+            "Shape from %s to %s failed to generate: %s",
+            ctx.start.cache_key(),
+            ctx.end.cache_key(),
+            error,
+        )
+
+
+class GeoJSONErrorWriter(ErrorObserver):
+    """
+    :py:class:`ErrorObserver` implementation which dumps all shape generation errors
+    as GeoJSON to the provided directory.
+
+    All error reasons must be serializable as JSON.
+    """
+
+    directory: Path
+
+    def __init__(self, directory: StrPath, /, clear: bool = False) -> None:
+        self.directory = Path(directory)
+
+        if clear:
+            for f in self.directory.iterdir():
+                if f.is_dir():
+                    shutil.rmtree(f)
+                else:
+                    f.unlink()
+
+    def context_to_filename(self, ctx: LegContext, error: Any) -> str:
+        start_key = ctx.start.cache_key()
+        end_key = ctx.end.cache_key()
+        return f"{start_key}__{end_key}.geojson"
+
+    def on_error(self, ctx: LegContext, error: Any, points: Sequence[ShapePoint]) -> None:
+        file_name = self.context_to_filename(ctx, error)
+        file_path = self.directory / file_name
+        with file_path.open("w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "error": error,
+                        "start_stop_id": ctx.start.cache_key(),
+                        "start_node_id": ctx.start.node,
+                        "end_stop_id": ctx.end.cache_key(),
+                        "end_node_id": ctx.end.node,
+                    },
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[lon, lat] for (lat, lon, _) in points],
+                    },
+                },
+                f,
+                ensure_ascii=False,
+                indent=2,
+            )
+
+
+class FallbackPolicy:
+    """
+    Base class for a fallback policy - objects which decide what to do when
+    a shape's leg fails to be generated.
+
+    The default implementation returns no substitutions, aborting entire shapes.
+    """
+
+    def substitute_leg(self, ctx: LegContext, error: Any) -> Sequence[ShapePoint]:
+        """
+        Return a substitute shape for the provided leg;
+        or an empty sequence to completely abandon the entire shape.
+        """
+        return []
+
+
+class StraightLineSubstitute(FallbackPolicy):
+    """
+    A :py:class:`FallbackPolicy` which substitutes failed shape segments by straight lines
+    between waypoints.
+    """
+
+    def distance(self, start: Waypoint, end: Waypoint) -> float:
+        """
+        Computes the distance between two waypoints, to match with
+        :py:class:`LegRouter` units. Defaults to :py:func:`impuls.tools.geo.earth_distance_m`
+        converted to **kilometers**.
+        """
+        return earth_distance_m(start.lat, start.lon, end.lat, end.lon) / 1000
+
+    def substitute_leg(self, ctx: LegContext, error: Any) -> Sequence[ShapePoint]:
+        dist = self.distance(ctx.start, ctx.end)
+        return [(ctx.start.lat, ctx.start.lon, 0.0), (ctx.end.lat, ctx.end.lon, dist)]
+
+
+class LegPlanner:
+    """
+    Base class for leg planners - objects which decide how a route between two
+    :py:class:`waypoints <Waypoint>` is generated; in particular if any extra waypoints
+    should be inserted.
+
+    The root planner (the one returned by
+    :py:meth:`AbstractGenerateShapes.create_leg_planner`) is only called with both waypoints
+    representing stops; but that might not hold if planners are composed/nested.
+
+    The default implementation doesn't add any waypoints, and simply returns
+    a single `LegContext(start, end)`.
+    """
+
+    def plan_waypoints(self, start: Waypoint, end: Waypoint) -> Iterable[LegContext]:
+        return [LegContext(start, end)]
+
+
+class ShapeValidator:
+    """
+    Base class for shape validators - objects which decide if a generate shape leg looks correct.
+
+    The default implementation allows all shapes.
+    """
+
+    def validate_leg(self, ctx: LegContext, points: Sequence[ShapePoint]) -> Any:
+        """
+        Checks if a shape segment looks correct.
+
+        If the shape leg looks correct, returns a false-y value, preferably None.
+
+        Otherwise, returns a truthy value representing the reason why the shape
+        looks incorrect. Users are encouraged to keep return values JSON serializable,
+        especially strings.
+        """
+        return None
+
+
+class MultiShapeValidator(ShapeValidator):
+    """
+    MultiShapeValidator is a :py:class`ShapeValidator` delegating the validation to multiple other
+    validators, returning the first encountered error (short circuiting), if any.
+    """
+
+    validators: tuple[ShapeValidator, ...]
+
+    def __init__(self, *validators: ShapeValidator) -> None:
+        self.validators = validators
+
+    def validate_leg(self, ctx: LegContext, points: Sequence[ShapePoint]) -> Any:
+        for validator in self.validators:
+            if error := validator.validate_leg(ctx, points):
+                return error
+        return None
+
+
+@dataclass
+class ShapeBuilder:
+    """
+    ShapeBuilder orchestrates all necessary single-responsibility
+    objects to actually build and generate shapes.
+
+    Users are not really supposed to subclass the builder,
+    if such a necessity arises, please file an issue.
+    """
+
+    snapper: StopSnapper
+    planner: LegPlanner
+    router: LegRouter
+    validator: ShapeValidator
+    fallback: FallbackPolicy
+    observer: ErrorObserver
+    stop_locations: Mapping[str, tuple[float, float]]
+
+    def build(self, stops: Iterable[StopKey]) -> GeneratedShape | None:
+        """Builds a shape between the provided stops."""
+        shape = GeneratedShape()
+
+        for leg_ctx in self.get_legs(stops):
+            if leg_points := self.build_leg(leg_ctx):
+                shape.append_leg(leg_ctx, leg_points)
+            else:
+                return None
+
+        shape.round()
+        return shape
+
+    def get_legs(self, stops: Iterable[StopKey]) -> list[LegContext]:
+        """Gets all legs of a shape, by querying the :py:class:`LegPlanner` for every stop pair."""
+        return [
+            leg
+            for stop_a, stop_b in pairwise(stops)
+            for leg in self.planner.plan_waypoints(
+                self.stop_to_waypoint(stop_a),
+                self.stop_to_waypoint(stop_b),
+            )
+        ]
+
+    def build_leg(self, ctx: LegContext) -> Sequence[ShapePoint]:
+        """
+        Builds a shape between two waypoints, by calling the :py:class:`StopSnapper`
+        and :py:class:`LegRouter`; and validating the segment with :py:class:`ShapeValidator`.
+
+        If the shape fails to generate or is deemed incorrect, calls the :py:class:`ErrorObserver`
+        and :py:class:`FallbackPolicy`.
+        """
+        # Snap stops to nodes
+        ctx.start.node = self.snapper.snap(ctx.start)
+        ctx.end.node = self.snapper.snap(ctx.end)
+        if ctx.start.node == 0 or ctx.end.node == 0:
+            return self.on_error(ctx, "unsnapped_waypoint", [])
+
+        # Generate the route
+        points = self.router.generate_leg(ctx)
+        if not points:
+            return self.on_error(ctx, "no_route", points)
+        elif error := self.validator.validate_leg(ctx, points):
+            return self.on_error(ctx, error, points)
+        return points
+
+    def on_error(
+        self,
+        ctx: LegContext,
+        error: Any,
+        points: Sequence[ShapePoint],
+    ) -> Sequence[ShapePoint]:
+        """
+        Deals with a shape error - invokes the :py:class:`ErrorObserver`
+        and gets the fallback shape from the :py:class:`FallbackPolicy`.
+        """
+        self.observer.on_error(ctx, error, points)
+        return self.fallback.substitute_leg(ctx, error)
+
+    def stop_to_waypoint(self, stop: StopKey) -> Waypoint:
+        lat, lon = self.stop_locations[stop[0]]
+        return Waypoint(id=stop, lat=lat, lon=lon)
+
+
+GraphT = TypeVar("GraphT")
+
+
+@dataclass_transform(kw_only_default=True, eq_default=False)
+@dataclass(kw_only=True, repr=False, eq=False)
+class AbstractGenerateShapes(Task, Generic[GraphT]):
+    """
+    Base abstract class for generating shapes, agnostic to any "routing graphs".
+
+    This class is mostly responsible for negotiating with the database -
+    querying for trips, inserting shapes and updating shape_dist_traveled,
+    but it also generates the shapes using the quasi-private :py:class:`ShapeBuilder`.
+
+    Responsibility for providing the routing graph and other required lays on
+    the programmer. Implementing shape generation involves
+    `injecting dependencies <https://en.wikipedia.org/wiki/Dependency_injection>`_
+    by overriding the :py:meth:`create_routing_graph`, :py:meth:`create_leg_router`,
+    :py:meth:`create_stop_snapper` and possibly other ``create_xxx`` methods.
+
+    AbstractGenerateShapes is a `kw-only dataclass <https://docs.python.org/3/library/dataclasses.html>`_,
+    in order to make adding new options/settings as easy as possible, without having
+    to write out enormous ``__init__`` methods manually. All subclasses are automatically
+    wrapped in `@dataclass` though a `__init_subclass__ <https://docs.python.org/3/reference/datamodel.html#object.__init_subclass__>`_
+    hook. To add new options, simply do::
+
+        class MyGenerateShapes(AbstractGenerateShapes[...]):
+            custom_knob: float
+            another_parameter_with_default: int = 42
+
+    And those parameters will automatically be added as parameters to the ``__init__``
+    method of MyGenerateShapes. `InitVar <https://docs.python.org/3/library/dataclasses.html#dataclasses.InitVar>`_
+    is more convoluted, as the base class uses one for the task name::
+
+        class MyGenerateShapes(AbstractGenerateShapes[...]):
+            custom_knob: InitVar[float | None] = None
+            custom_knob_resolved: float = field(init=False)
+
+            def __post_init__(self, task_name: str | None, custom_knob: float | None) -> None:
+                super().__post_init__(task_name)
+                self.custom_knob_resolved = custom_knob or fallback_custom_knob()
+
+    Of course, if you don't want to add new options, you don't need to worry about all that.
+    """
+
+    routes: selector.Routes
+    """Selector for which routes shapes should be generated."""
+
+    id_prefix: str
+    """
+    Prefix for generated shape IDs; which are consecutive integers.
+
+    Users must ensure the prefix guarantees shape ID uniqueness,
+    particularly if using generate shapes multiple times,
+    or if the database already has shapes.
+    """
+
+    overwrite: bool = False
+    """
+    Should any existing shapes (in selected routes) be overwritten?
+
+    Note that this only replaces :py:attr:`Trip.shape_id <impuls.model.Trip.shape_id>`,
+    without removing shapes; as those shapes may be used by unselected trips.
+    Vacuum unused shapes afterwards with an :py:class:`ExecuteSQL <impuls.tasks.ExecuteSQL>`
+    or a :py:class:`RemoveUnusedEntities <impuls.tasks.RemoveUnusedEntities>` task.
+
+    Defaults to ``False``.
+    """
+
+    progress_report_step: int = 100
+    """
+    How often should an info message be logged with shape generation progress?
+
+    Defaults to ``100`` - every 100th shape causes an info message to be logged.
+    All other generated shapes cause a debug logging message.
+    """
+
+    task_name: InitVar[str | None] = None
+
+    def __post_init__(self, task_name: str | None) -> None:
+        super().__init__(task_name)
+
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+        dataclass(kw_only=True, repr=False, eq=False)(cls)
+
+    @abstractmethod
+    def create_routing_graph(self, r: TaskRuntime) -> GraphT:
+        """
+        Instantiates a routing graph, which will be passed along to other shape-building classes.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_stop_snapper(self, r: TaskRuntime, graph: GraphT) -> StopSnapper:
+        """
+        Instantiates a :py:class:`StopSnapper`, used to match :py:class:`Waypoints <Waypoint>`
+        with nodes in the routing graph.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_leg_router(self, r: TaskRuntime, graph: GraphT) -> LegRouter:
+        """
+        Instantiates a :py:class:`LegRouter`, used to generate shape segments between
+        two :py:class:`Waypoints <Waypoint>`.
+        """
+        raise NotImplementedError
+
+    def create_leg_planner(self, r: TaskRuntime, graph: GraphT) -> LegPlanner:
+        """
+        Instantiates a :py:class:`LegPlanner`, used to generate all waypoints
+        to traverse between two stops.
+
+        The default implementation simply returns no waypoints; converting the stop pair to
+        a single :py:class:`leg <LegContext>`.
+        """
+        return LegPlanner()
+
+    def create_shape_validator(self, r: TaskRuntime, graph: GraphT) -> ShapeValidator:
+        """
+        Instantiates a :py:class:`ShapeValidator`, used to determine if
+        a shape segment looks correct.
+
+        The default implementation allows any shapes.
+        """
+        return ShapeValidator()
+
+    def create_fallback_policy(self, r: TaskRuntime, graph: GraphT) -> FallbackPolicy:
+        """
+        Instantiates a :py:class:`FallbackPolicy`, used to determine what to do when
+        a shape segment fails to generate.
+
+        The default implementation aborts the entire shape.
+        """
+        return FallbackPolicy()
+
+    def create_error_observer(self, r: TaskRuntime, graph: GraphT) -> ErrorObserver:
+        """
+        Instantiates an :py:class:`ErrorObserver`, a callback when shape segment fails to generate.
+
+        The default implementation :py:class:`logs failures as warnings <ErrorLogger>`.
+        """
+        return ErrorLogger(self.logger)
+
+    def create_shape_builder(self, r: TaskRuntime, graph: GraphT) -> ShapeBuilder:
+        """
+        Instantiates a :py:class:`ShapeBuilder`, by calling all other ``create_xxx``` methods.
+
+        This should not really by overridden - if there's a need for that, file an issue.
+        """
+        return ShapeBuilder(
+            snapper=self.create_stop_snapper(r, graph),
+            planner=self.create_leg_planner(r, graph),
+            router=self.create_leg_router(r, graph),
+            validator=self.create_shape_validator(r, graph),
+            fallback=self.create_fallback_policy(r, graph),
+            observer=self.create_error_observer(r, graph),
+            stop_locations=self.get_stop_locations(r),
+        )
+
+    def execute(self, r: TaskRuntime) -> None:
+        """
+        Generates shapes by:
+
+        1. gathering trips to process,
+        2. creating the routing graph,
+        3. creating the shape builder,
+        4. generating shapes and inserting the into the database.
+        """
+
+        self.logger.info("Getting trips to process")
+        trip_ids = self.get_trips_to_process(r.db)
+        if not trip_ids:
+            self.logger.warning("No trips to process")
+            return
+
+        grouped_trips = self.group_trips(r.db, trip_ids)
+        self.remove_existing_shapes(r.db, trip_ids)
+
+        self.logger.info("Creating the routing graph")
+        graph = self.create_routing_graph(r)
+
+        self.logger.info("Creating the shape builder")
+        builder = self.create_shape_builder(r, graph)
+
+        self.generate_shapes(r.db, grouped_trips, builder)
+        self.logger.info("Shape generation completed")
+
+    def get_trips_to_process(self, db: DBConnection) -> Sequence[str]:
+        """
+        Gets identifiers of all trips to generate shapes for.
+
+        This returns all trips of routes selected by :py:attr:`the provided selector <routes>`;
+        that don't already have shapes (``shape_id IS NULL``) unless :py:attr:`Options.overwrite`
+        is set.
+        """
+
+        route_ids = list(self.routes.find_ids(db))
+        query = (
+            "SELECT trip_id FROM trips WHERE route_id = ?"
+            if self.overwrite
+            else "SELECT trip_id FROM trips WHERE route_id = ? AND shape_id IS NULL"
+        )
+        return [
+            cast(str, row[0])
+            for route_id in route_ids
+            for row in db.raw_execute(query, (route_id,))
+        ]
+
+    def remove_existing_shapes(self, db: DBConnection, trip_ids: Iterable[str]) -> None:
+        """Removes shapes of the provided trips, but only if :py:attr:`Options.overwrite` is set."""
+        if self.overwrite:
+            with db.transaction():
+                db.raw_execute_many(
+                    "UPDATE trips SET shape_id = NULL WHERE trip_id = ?",
+                    ((trip_id,) for trip_id in trip_ids),
+                )
+
+    def generate_shapes(
+        self,
+        db: DBConnection,
+        grouped_trips: Mapping[ShapeKey, Sequence[str]],
+        builder: ShapeBuilder,
+    ) -> None:
+        """
+        Generates and :py:meth:`assigns <assign_shape>` shapes for the provided,
+        already grouped trips.
+        """
+
+        total = len(grouped_trips)
+        for idx, (stops, trip_ids) in enumerate(grouped_trips.items()):
+            (self.logger.info if idx % self.progress_report_step == 0 else self.logger.debug)(
+                "Generating shape %d/%d (%.2f %%)",
+                idx,
+                total,
+                100 * idx / total,
+            )
+
+            shape_id = f"{self.id_prefix}{idx}"
+            shape = builder.build(stops)
+            if shape:
+                self.assign_shape(db, shape_id, shape, trip_ids)
+
+    def assign_shape(
+        self,
+        db: DBConnection,
+        shape_id: str,
+        shape: GeneratedShape,
+        trip_ids: Sequence[str],
+    ) -> None:
+        """
+        Inserts the provided shape and assigns it to the trips.
+
+        This amounts to 4 different operations, wrapped in a transaction:
+
+        1. ``INSERT INTO shapes``,
+        2. ``INSERT INTO shape_points``,
+        3. ``UPDATE trips SET shape_id``,
+        4. ``UPDATE stop_times SET shape_dist_traveled``.
+        """
+
+        with db.transaction():
+            db.raw_execute("INSERT INTO shapes (shape_id) VALUES (?)", (shape_id,))
+            db.raw_execute_many(
+                "INSERT INTO shape_points (shape_id, sequence, lat, lon, shape_dist_traveled) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    (shape_id, idx, lat, lon, dist)
+                    for idx, (lat, lon, dist) in enumerate(shape.points)
+                ),
+            )
+            db.raw_execute_many(
+                "UPDATE trips SET shape_id = ? WHERE trip_id = ?",
+                ((shape_id, trip_id) for trip_id in trip_ids),
+            )
+            db.raw_execute_many(
+                "UPDATE stop_times SET shape_dist_traveled = ? "
+                "WHERE trip_id = ? AND stop_sequence = ?",
+                (
+                    (dist, trip_id, idx)
+                    for trip_id in trip_ids
+                    for idx, dist in shape.distances.items()
+                ),
+            )
+
+    def group_trips(
+        self,
+        db: DBConnection,
+        trip_ids: Iterable[str],
+    ) -> Mapping[ShapeKey, Sequence[str]]:
+        """
+        Groups the provided trips by the same :py:class:`ShapeKey` - sequence of stops.
+
+        Trips' shape keys are retrieved by calling :py:meth:`get_trip_stops`.
+        """
+        by_stops = defaultdict[ShapeKey, list[str]](list)
+        for trip_id in trip_ids:
+            trip_stops = self.get_trip_stops(db, trip_id)
+            by_stops[trip_stops].append(trip_id)
+        return by_stops
+
+    def get_trip_stops(self, db: DBConnection, trip_id: str) -> ShapeKey:
+        """
+        Retrieves all stops of a trip - its :py:class:`ShapeKey`.
+
+        The default implementation simply executes::
+
+            SELECT stop_id, stop_sequence
+            FROM stop_times
+            WHERE trip_id = ?
+            ORDER BY stop_sequence ASC
+        """
+
+        return tuple(
+            (cast(str, i[0]), cast(int, i[1]))
+            for i in db.raw_execute(
+                "SELECT stop_id, stop_sequence FROM stop_times "
+                "WHERE trip_id = ? ORDER BY stop_sequence ASC",
+                (trip_id,),
+            )
+        )
+
+    def get_stop_locations(self, r: TaskRuntime) -> dict[str, tuple[float, float]]:
+        """
+        Gets positions of all stops, for snapping.
+
+        The default implementation simply calls ``SELECT stop_id, lat, lon FROM stops``,
+        as that's significantly easier than actually filtering out used stops,
+        without increasing memory that much.
+        """
+        with r.db.raw_execute("SELECT stop_id, lat, lon FROM stops") as query:
+            rows = cast(Iterable[tuple[str, float, float]], query)
+            return {i[0]: (i[1], i[2]) for i in rows}
+
+
+class RoutxKDTreeStopSnapper(StopSnapper):
+    """
+    Snap stops to a `routx routing graph <https://pypi.org/project/routx/#user-content-routxgraph>`_
+    using a `k-d tree <https://pypi.org/project/routx/#user-content-routxkdtree>`_.
+    """
+
+    kd_tree: routx.KDTree
+
+    def __init__(self, graph: routx.Graph) -> None:
+        super().__init__()
+        self.kd_tree = routx.KDTree.build(graph)
+
+    def snap(self, pt: Waypoint) -> int:
+        return self.kd_tree.find_nearest_node(pt.lat, pt.lon).id
+
+
+class RoutxLegRouter(LegRouter):
+    """
+    Generates routes on a
+    `routx routing graph <https://pypi.org/project/routx/#user-content-routxgraph>`_;
+    simplifying the results with the
+    `Ramer-Douglas-Peucker algorithm <https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm>`_.
+    """
+
+    graph: routx.Graph
+
+    simplify_epsilon: float
+    """
+    Threshold, in decimal degrees, for the `RDP simplification algorithm <https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm>`_
+    to determine if a node "sticks out" enough to be considered important and preserved.
+
+    Defaults to ``1e-5``, but can be set to a non-finite number (e.g. ``nan``)
+    to disable simplification entirely.
+    """
+
+    def __init__(self, graph: routx.Graph, simplify_epsilon: float = 1e-5) -> None:
+        super().__init__()
+        self.graph = graph
+        self.simplify_epsilon = simplify_epsilon
+
+    def generate_leg(self, ctx: LegContext) -> Sequence[ShapePoint]:
+        assert ctx.start.node != 0
+        assert ctx.end.node != 0
+
+        try:
+            nodes = self.graph.find_route(ctx.start.node, ctx.end.node)
+        except routx.StepLimitExceeded:
+            return []
+
+        if isfinite(self.simplify_epsilon):
+            nodes = self.graph.simplify_route(nodes, self.simplify_epsilon)
+
+        return self.nodes_to_shape_points(nodes)
+
+    def nodes_to_shape_points(self, nodes: Iterable[int]) -> list[ShapePoint]:
+        points = list[ShapePoint]()
+        for node_id in nodes:
+            node = self.graph[node_id]
+            if points:
+                dist = points[-1][2] + routx.earth_distance(
+                    points[-1][0],
+                    points[-1][1],
+                    node.lat,
+                    node.lon,
+                )
+            else:
+                dist = 0.0
+            points.append((node.lat, node.lon, dist))
+        return points
+
+
+class GenerateShapes(AbstractGenerateShapes[routx.Graph]):
+    """
+    Generates shapes based on an routing data stored in an
+    `OpenStreetMap XML <https://wiki.openstreetmap.org/wiki/OSM_XML>`_ or
+    an `OpenStreetMap PBF <https://wiki.openstreetmap.org/wiki/PBF_Format>`_ file
+    using the `routx library <https://pypi.org/project/routx/>`_.
+
+    Note that using actual data from `OpenStreetMap <https://www.openstreetmap.org/#map=15/51.91770/-2.57938>`_
+    like `Geofabrik data extracts <https://download.geofabrik.de/>`_ is
+    `licensed under ODbL <https://www.openstreetmap.org/copyright/>`_; making your resulting file
+    subject to appropriate attributions.
+
+    For simple, fixed-track networks (anything rail-based), users are encouraged to draw
+    their own routing graphs using tools like `JOSM <https://josm.eu/>`_.
+
+    Each stop is snapped to its closest node in the routing graph, and then
+    shortest routes between each pair of stops are found using the
+    `A* algorithm <https://en.wikipedia.org/wiki/A*_search_algorithm>`_. Note that this might
+    not actually be desirable, especially with hyper-mapped rail data, where every single
+    track is mapped as a separate way. If the node distribution and stop position align
+    just right, a stop might be snapped to a way in the opposite direction, resulting in wonky
+    shapes.
+
+    This implementation doesn't do any validation of generated shapes, nor
+    does it prevent abrupt 180° turns at stops. It's a pretty "dumb" step - snap stops
+    to nodes, and find the cheapest route between those nodes. Extra behavior can be
+    obtained by subclassing this task and `injecting <https://en.wikipedia.org/wiki/Dependency_injection>`_
+    extra behavior by overriding the ``create_xxx`` methods. See the documentation for
+    :py:class:`AbstractGenerateShapes` for more details.
+    """
+
+    osm_resource: str
+    """
+    Name of the resource containing the `OSM XML <https://wiki.openstreetmap.org/wiki/OSM_XML>`_
+    or `OSM PBF <https://wiki.openstreetmap.org/wiki/PBF_Format>`_ routing graph.
+    """
+
+    osm_profile: InitVar[routx.OsmProfile | routx.OsmCustomProfile | None] = None
+    """
+    Routing profile, which describes how OSM data should be converted to a routing graph.
+    See documentation for `routx.OsmProfile <https://pypi.org/project/routx/#user-content-routxosmprofile>`_
+    and `routx.OsmCustomProfile <https://pypi.org/project/routx/#user-content-routxosmcustomprofile>`_.
+
+    Can be omitted (set to ``None``) only when the :py:attr:`route selector <routes>` explicitly
+    states a :py:attr:`tram <impuls.model.Route.Type.TRAM>`,
+    :py:attr:`metro <impuls.model.Route.Type.METRO>`,
+    :py:attr:`rail <impuls.model.Route.Type.RAIL>`, or :py:attr:`bus <impuls.model.Route.Type.BUS>`
+    route type. In this case, a corresponding
+    `predefined profile <https://pypi.org/project/routx/#user-content-routxosmprofile>`_ is used.
+    """
+
+    osm_profile_resolved: routx.OsmProfile | routx.OsmCustomProfile = field(init=False)
+    """
+    This is not a parameter of the task; rather it's computed in
+    `post-init processing <https://docs.python.org/3/library/dataclasses.html#post-init-processing>`_
+    based on the value of :py:attr:`osm_profile` and :py:attr:`routes`.
+
+    Resolved routing profile for `routx <https://pypi.org/project/routx/>`_.
+    """
+
+    osm_bbox: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
+    """
+    Bounding box for OpenStreetMap data. Any features outside of this box are ignored.
+    Useful when loading a big OSM extract to route for a smaller area, to reduce memory usage.
+
+    In order: left (min lon), bottom (min lat), right (max lon), top (max lat).
+
+    Ignored if all values are 0, or one value is not finite.
+    """
+
+    max_stop_snap_distance_m: float = 500.0
+    """
+    Maximum allowed distance from a stop to its snapped node.
+
+    When this distance is exceeded, the entire shape is dropped.
+    """
+
+    simplify_epsilon: float = 1e-5
+    """
+    Threshold for shape simplification using the
+    `Ramer-Douglas-Peucker algorithm <https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm>`_,
+    in decimal degrees.
+
+    Set to ``nan`` to disable.
+    """
+
+    def __post_init__(
+        self,
+        task_name: str | None,
+        osm_profile: routx.OsmProfile | routx.OsmCustomProfile | None,
+    ) -> None:
+        super().__post_init__(task_name)
+        self.osm_profile_resolved = self.resolve_osm_profile(self.routes, osm_profile)
+
+    def get_routing_graph(self, r: TaskRuntime) -> routx.Graph:
+        g = routx.Graph()
+        g.add_from_osm_file(
+            r.resources[self.osm_resource].stored_at,
+            self.osm_profile_resolved,
+            bbox=self.osm_bbox,
+        )
+        return g
+
+    def create_stop_snapper(self, r: TaskRuntime, graph: routx.Graph) -> StopSnapper:
+        return (
+            RoutxKDTreeStopSnapper(graph)
+            .distance_limited(
+                lambda node_id: ((n := graph[node_id]).lat, n.lon),
+                self.max_stop_snap_distance_m,
+            )
+            .cached()
+        )
+
+    def create_leg_router(self, r: TaskRuntime, graph: routx.Graph) -> LegRouter:
+        return RoutxLegRouter(graph, self.simplify_epsilon)
+
+    @staticmethod
+    def resolve_osm_profile(
+        routes: selector.Routes,
+        profile: routx.OsmProfile | routx.OsmCustomProfile | None,
+    ) -> routx.OsmProfile | routx.OsmCustomProfile:
+        if profile is not None:
+            return profile
+
+        elif routes.type is Route.Type.TRAM:
+            return routx.OsmProfile.TRAM
+
+        elif routes.type is Route.Type.METRO:
+            return routx.OsmProfile.SUBWAY
+
+        elif routes.type is Route.Type.RAIL:
+            return routx.OsmProfile.RAILWAY
+
+        elif routes.type is Route.Type.BUS:
+            return routx.OsmProfile.BUS
+
+        else:
+            raise ValueError("missing osm_profile in GenerateShapes options")

--- a/impuls/tasks/generate_shapes.py
+++ b/impuls/tasks/generate_shapes.py
@@ -327,6 +327,7 @@ class GeoJSONErrorWriter(ErrorObserver):
 
     def __init__(self, directory: StrPath, /, clear: bool = False) -> None:
         self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True)
 
         if clear:
             for f in self.directory.iterdir():

--- a/impuls/tasks/generate_shapes.py
+++ b/impuls/tasks/generate_shapes.py
@@ -11,7 +11,7 @@ from dataclasses import InitVar, dataclass, field
 from itertools import pairwise
 from math import isfinite
 from pathlib import Path
-from typing import Any, Generic, Self, TypeAlias, TypeVar, cast
+from typing import Any, Generic, TypeAlias, TypeVar, cast
 
 import routx
 from typing_extensions import dataclass_transform
@@ -21,7 +21,7 @@ from ..db import DBConnection
 from ..model import Route
 from ..task import Task, TaskRuntime
 from ..tools.geo import earth_distance_m
-from ..tools.types import StrPath
+from ..tools.types import Self, StrPath
 
 StopKey: TypeAlias = tuple[str, int]
 """

--- a/impuls/tasks/generate_shapes.py
+++ b/impuls/tasks/generate_shapes.py
@@ -414,6 +414,10 @@ class LegPlanner:
 
     The default implementation doesn't add any waypoints, and simply returns
     a single `LegContext(start, end)`.
+
+    If the LegPlanner knows the exact nodes corresponding to waypoints, it may
+    fill in their :py:attr:`Waypoint.node` attributes. This will in turn bypass
+    :py:class:`stop snapping <StopSnapper>` for those waypoints.
     """
 
     def plan_waypoints(self, start: Waypoint, end: Waypoint) -> Iterable[LegContext]:
@@ -509,8 +513,11 @@ class ShapeBuilder:
         and :py:class:`FallbackPolicy`.
         """
         # Snap stops to nodes
-        ctx.start.node = self.snapper.snap(ctx.start)
-        ctx.end.node = self.snapper.snap(ctx.end)
+        if ctx.start.node == 0:
+            ctx.start.node = self.snapper.snap(ctx.start)
+        if ctx.end.node == 0:
+            ctx.end.node = self.snapper.snap(ctx.end)
+
         if ctx.start.node == 0 or ctx.end.node == 0:
             return self.on_error(ctx, "unsnapped_waypoint", [])
 

--- a/impuls/tasks/generate_shapes.py
+++ b/impuls/tasks/generate_shapes.py
@@ -424,7 +424,7 @@ class LegPlanner:
 
 class ShapeValidator:
     """
-    Base class for shape validators - objects which decide if a generate shape leg looks correct.
+    Base class for shape validators - objects which decide if a generated shape leg looks correct.
 
     The default implementation allows all shapes.
     """
@@ -444,7 +444,7 @@ class ShapeValidator:
 
 class MultiShapeValidator(ShapeValidator):
     """
-    MultiShapeValidator is a :py:class`ShapeValidator` delegating the validation to multiple other
+    MultiShapeValidator is a :py:class:`ShapeValidator` delegating the validation to multiple other
     validators, returning the first encountered error (short circuiting), if any.
     """
 
@@ -691,7 +691,7 @@ class AbstractGenerateShapes(Task, Generic[GraphT]):
 
     def create_shape_builder(self, r: TaskRuntime, graph: GraphT) -> ShapeBuilder:
         """
-        Instantiates a :py:class:`ShapeBuilder`, by calling all other ``create_xxx``` methods.
+        Instantiates a :py:class:`ShapeBuilder`, by calling all other ``create_xxx`` methods.
 
         This should not really by overridden - if there's a need for that, file an issue.
         """
@@ -738,7 +738,7 @@ class AbstractGenerateShapes(Task, Generic[GraphT]):
         Gets identifiers of all trips to generate shapes for.
 
         This returns all trips of routes selected by :py:attr:`the provided selector <routes>`;
-        that don't already have shapes (``shape_id IS NULL``) unless :py:attr:`Options.overwrite`
+        that don't already have shapes (``shape_id IS NULL``) unless :py:attr:`overwrite`
         is set.
         """
 
@@ -953,7 +953,7 @@ class RoutxLegRouter(LegRouter):
 
 class GenerateShapes(AbstractGenerateShapes[routx.Graph]):
     """
-    Generates shapes based on an routing data stored in an
+    Generates shapes based on routing data stored in an
     `OpenStreetMap XML <https://wiki.openstreetmap.org/wiki/OSM_XML>`_ or
     an `OpenStreetMap PBF <https://wiki.openstreetmap.org/wiki/PBF_Format>`_ file
     using the `routx library <https://pypi.org/project/routx/>`_.
@@ -979,7 +979,7 @@ class GenerateShapes(AbstractGenerateShapes[routx.Graph]):
     to nodes, and find the cheapest route between those nodes. Extra behavior can be
     obtained by subclassing this task and `injecting <https://en.wikipedia.org/wiki/Dependency_injection>`_
     extra behavior by overriding the ``create_xxx`` methods. See the documentation for
-    :py:class:`AbstractGenerateShapes` for more details.
+    :py:class:`~impuls.tasks.generate_shapes.AbstractGenerateShapes` for more details.
     """
 
     osm_resource: str

--- a/impuls/tasks/generate_shapes.py
+++ b/impuls/tasks/generate_shapes.py
@@ -115,10 +115,8 @@ class GeneratedShape:
         if isinstance(ctx.end.id, tuple):
             self.distances[ctx.end.id[1]] = self.points[-1][2]
 
-    def round(self, coord_precision: int = 6, dist_precision: int | None = 3) -> None:
+    def round(self, coord_precision: int = 6, dist_precision: int = 3) -> None:
         """Rounds all stored coordinates and distances to the provided number of decimal places."""
-        dist_precision = coord_precision if dist_precision is None else dist_precision
-
         self.points = [
             (round(lat, coord_precision), round(lon, coord_precision), round(dist, dist_precision))
             for (lat, lon, dist) in self.points
@@ -305,7 +303,7 @@ class ErrorLogger(ErrorObserver):
 
     logger: logging.Logger
 
-    def __init__(self, logger: logging.Logger | None) -> None:
+    def __init__(self, logger: logging.Logger | None = None) -> None:
         self.logger = logger or logging.getLogger("Task.GenerateShapes")
 
     def on_error(self, ctx: LegContext, error: Any, points: Sequence[ShapePoint]) -> None:
@@ -413,7 +411,7 @@ class LegPlanner:
     representing stops; but that might not hold if planners are composed/nested.
 
     The default implementation doesn't add any waypoints, and simply returns
-    a single `LegContext(start, end)`.
+    a single ``LegContext(start, end)``.
 
     If the LegPlanner knows the exact nodes corresponding to waypoints, it may
     fill in their :py:attr:`Waypoint.node` attributes. This will in turn bypass
@@ -714,7 +712,7 @@ class AbstractGenerateShapes(Task, Generic[GraphT]):
         1. gathering trips to process,
         2. creating the routing graph,
         3. creating the shape builder,
-        4. generating shapes and inserting the into the database.
+        4. generating shapes and inserting them into the database.
         """
 
         self.logger.info("Getting trips to process")
@@ -1016,7 +1014,7 @@ class GenerateShapes(AbstractGenerateShapes[routx.Graph]):
     osm_bbox: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
     """
     Bounding box for OpenStreetMap data. Any features outside of this box are ignored.
-    Useful when loading a big OSM extract to route for a smaller area, to reduce memory usage.
+    Useful when loading a big OSM extract to route over a smaller area, to reduce memory usage.
 
     In order: left (min lon), bottom (min lat), right (max lon), top (max lat).
 
@@ -1047,7 +1045,7 @@ class GenerateShapes(AbstractGenerateShapes[routx.Graph]):
         super().__post_init__(task_name)
         self.osm_profile_resolved = self.resolve_osm_profile(self.routes, osm_profile)
 
-    def get_routing_graph(self, r: TaskRuntime) -> routx.Graph:
+    def create_routing_graph(self, r: TaskRuntime) -> routx.Graph:
         g = routx.Graph()
         g.add_from_osm_file(
             r.resources[self.osm_resource].stored_at,

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,7 @@ py.install_sources(
     'impuls/tasks/assign_directions.py',
     'impuls/tasks/exec_sql.py',
     'impuls/tasks/extend_calendars.py',
+    'impuls/tasks/generate_shapes.py',
     'impuls/tasks/generate_trip_headsign.py',
     'impuls/tasks/load_busman.py',
     'impuls/tasks/load_db.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,12 @@ name = "impuls"
 version = "2.4.1"
 readme = "readme.md"
 requires-python = "~=3.10"
-dependencies = ["requests ~= 2.32", "pyyaml ~= 6.0", "typing_extensions ~= 4.1"]
+dependencies = [
+    "requests ~= 2.32",
+    "routx ~= 1.1",
+    "pyyaml ~= 6.0",
+    "typing_extensions ~= 4.1"
+]
 authors = [{name = "Mikołaj Kuranowski", email = "mkuranowski@gmail.com"}]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests ~= 2.32
+routx ~= 1.1
 pyyaml ~= 6.0
 typing_extensions ~= 4.1

--- a/tests/tasks/fixtures/wkd-shape-graph.osm
+++ b/tests/tasks/fixtures/wkd-shape-graph.osm
@@ -1,0 +1,297 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' upload='false' generator='JOSM'>
+  <node id='-26136' action='modify' lat='52.22761541515' lon='21.00002288282' />
+  <node id='-26138' action='modify' lat='52.22746426596' lon='20.99932014406' />
+  <node id='-26139' action='modify' lat='52.226767662' lon='20.99601029277' />
+  <node id='-26140' action='modify' lat='52.22578845031' lon='20.99118231654' />
+  <node id='-26141' action='modify' lat='52.22541384684' lon='20.98947643161' />
+  <node id='-26142' action='modify' lat='52.22427687309' lon='20.98450898051' />
+  <node id='-26143' action='modify' lat='52.22263379601' lon='20.97758888125' />
+  <node id='-26144' action='modify' lat='52.22226573841' lon='20.9763228786' />
+  <node id='-26145' action='modify' lat='52.22198969321' lon='20.97517489314' />
+  <node id='-26146' action='modify' lat='52.22164792058' lon='20.97359775424' />
+  <node id='-26147' action='modify' lat='52.22135215369' lon='20.97257851481' />
+  <node id='-26148' action='modify' lat='52.22110239344' lon='20.97178458095' />
+  <node id='-26149' action='modify' lat='52.2208394864' lon='20.97057222247' />
+  <node id='-26150' action='modify' lat='52.22060944146' lon='20.96963881373' />
+  <node id='-26151' action='modify' lat='52.22003761031' lon='20.96810459018' />
+  <node id='-26152' action='modify' lat='52.21970896839' lon='20.96687077403' />
+  <node id='-26153' action='modify' lat='52.219452626' lon='20.96557258487' />
+  <node id='-26154' action='modify' lat='52.2191305527' lon='20.96378086925' />
+  <node id='-26155' action='modify' lat='52.21890049891' lon='20.96232174754' />
+  <node id='-26156' action='modify' lat='52.21845353385' lon='20.96020816684' />
+  <node id='-26157' action='modify' lat='52.21817746496' lon='20.95929621577' />
+  <node id='-26158' action='modify' lat='52.21778307784' lon='20.9585022819' />
+  <node id='-26159' action='modify' lat='52.2172572229' lon='20.95782636523' />
+  <node id='-26160' action='modify' lat='52.21657360217' lon='20.95722555041' />
+  <node id='-26161' action='modify' lat='52.21579794284' lon='20.95658182025' />
+  <node id='-26162' action='modify' lat='52.21523919679' lon='20.95576642871' />
+  <node id='-26163' action='modify' lat='52.21477247411' lon='20.95470427394' />
+  <node id='-26164' action='modify' lat='52.21445036687' lon='20.95332025409' />
+  <node id='-26165' action='modify' lat='52.21437148311' lon='20.95206498027' />
+  <node id='-26166' action='modify' lat='52.21439120406' lon='20.94791292071' />
+  <node id='-26167' action='modify' lat='52.21437805676' lon='20.94479082942' />
+  <node id='-26168' action='modify' lat='52.21421371516' lon='20.94337462306' />
+  <node id='-26169' action='modify' lat='52.21367467046' lon='20.94162582278' />
+  <node id='-26170' action='modify' lat='52.21292525597' lon='20.94041346431' />
+  <node id='-26171' action='modify' lat='52.2120114791' lon='20.93965171695' />
+  <node id='-26172' action='modify' lat='52.21070980765' lon='20.9389543426' />
+  <node id='-26173' action='modify' lat='52.20967107276' lon='20.93869685054' />
+  <node id='-26174' action='modify' lat='52.20879667583' lon='20.9389543426' />
+  <node id='-26175' action='modify' lat='52.20798143312' lon='20.9395766151' />
+  <node id='-26176' action='modify' lat='52.20657444681' lon='20.94090699077' />
+  <node id='-26177' action='modify' lat='52.20530549103' lon='20.94228028178' />
+  <node id='-26178' action='modify' lat='52.20403649902' lon='20.94368575931' />
+  <node id='-26179' action='modify' lat='52.20335925011' lon='20.94409345508' />
+  <node id='-26180' action='modify' lat='52.20275432002' lon='20.94427584529' />
+  <node id='-26181' action='modify' lat='52.20206390062' lon='20.94417928576' />
+  <node id='-26182' action='modify' lat='52.20138662165' lon='20.94370721698' />
+  <node id='-26183' action='modify' lat='52.19846697083' lon='20.94079970241' />
+  <node id='-26184' action='modify' lat='52.19700049728' lon='20.93905090213' />
+  <node id='-26185' action='modify' lat='52.19446200268' lon='20.93583225131' />
+  <node id='-26186' action='modify' lat='52.19141035615' lon='20.931991328' />
+  <node id='-26187' action='modify' lat='52.18780598657' lon='20.92738865733' />
+  <node id='-26188' action='modify' lat='52.18707586882' lon='20.92617629886' />
+  <node id='-26189' action='modify' lat='52.18667462784' lon='20.9251463306' />
+  <node id='-26190' action='modify' lat='52.18649045044' lon='20.92448114276' />
+  <node id='-26191' action='modify' lat='52.18434604311' lon='20.91612337947' />
+  <node id='-26192' action='modify' lat='52.18214232662' lon='20.90760468364' />
+  <node id='-26193' action='modify' lat='52.18137922321' lon='20.90464352489' />
+  <node id='-26194' action='modify' lat='52.17854378464' lon='20.89363573909' />
+  <node id='-26195' action='modify' lat='52.1753660366' lon='20.88128684878' />
+  <node id='-26196' action='modify' lat='52.17179326616' lon='20.86746810794' />
+  <node id='-26197' action='modify' lat='52.17120764658' lon='20.86510776401' />
+  <node id='-26198' action='modify' lat='52.17095760441' lon='20.86360572696' />
+  <node id='-26199' action='modify' lat='52.17038513416' lon='20.85897086978' />
+  <node id='-26200' action='modify' lat='52.16899669869' lon='20.84757684588' />
+  <node id='-26201' action='modify' lat='52.1687663853' lon='20.84543107867' />
+  <node id='-26202' action='modify' lat='52.16878612649' lon='20.84430455089' />
+  <node id='-26203' action='modify' lat='52.16891115386' lon='20.84298490405' />
+  <node id='-26204' action='modify' lat='52.16914804684' lon='20.84194420695' />
+  <node id='-26205' action='modify' lat='52.16939151887' lon='20.84118245959' />
+  <node id='-26206' action='modify' lat='52.170556218' lon='20.83791016459' />
+  <node id='-26207' action='modify' lat='52.1709312841' lon='20.8366012466' />
+  <node id='-26208' action='modify' lat='52.17118132642' lon='20.83518504024' />
+  <node id='-26209' action='modify' lat='52.1711944865' lon='20.83262084842' />
+  <node id='-26210' action='modify' lat='52.1711352661' lon='20.82735298991' />
+  <node id='-26211' action='modify' lat='52.17099708485' lon='20.82623719096' />
+  <node id='-26212' action='modify' lat='52.17056937826' lon='20.82489608645' />
+  <node id='-26213' action='modify' lat='52.16991794033' lon='20.82391976237' />
+  <node id='-26214' action='modify' lat='52.16893747536' lon='20.82325457454' />
+  <node id='-26215' action='modify' lat='52.16761480046' lon='20.82236408114' />
+  <node id='-26216' action='modify' lat='52.16570639426' lon='20.82056163669' />
+  <node id='-26217' action='modify' lat='52.16235003307' lon='20.81731079936' />
+  <node id='-26218' action='modify' lat='52.16161949739' lon='20.81660269618' />
+  <node id='-26219' action='modify' lat='52.16069808393' lon='20.81578730464' />
+  <node id='-26220' action='modify' lat='52.15996093943' lon='20.81547616839' />
+  <node id='-26221' action='modify' lat='52.15907240081' lon='20.81543325305' />
+  <node id='-26222' action='modify' lat='52.15761120985' lon='20.81557272792' />
+  <node id='-26223' action='modify' lat='52.15688717853' lon='20.81533669353' />
+  <node id='-26224' action='modify' lat='52.15618946449' lon='20.81487535357' />
+  <node id='-26225' action='modify' lat='52.15455703419' lon='20.81340550303' />
+  <node id='-26226' action='modify' lat='52.15359597868' lon='20.81261156917' />
+  <node id='-26227' action='modify' lat='52.152707313' lon='20.81213950038' />
+  <node id='-26228' action='modify' lat='52.15143023644' lon='20.81194638133' />
+  <node id='-26229' action='modify' lat='52.1480991324' lon='20.81135629535' />
+  <node id='-26230' action='modify' lat='52.14624255916' lon='20.81099151492' />
+  <node id='-26231' action='modify' lat='52.14557759743' lon='20.81056236148' />
+  <node id='-26232' action='modify' lat='52.14493237755' lon='20.80977915645' />
+  <node id='-26233' action='modify' lat='52.14444516451' lon='20.80857752681' />
+  <node id='-26234' action='modify' lat='52.14283864049' lon='20.80329893947' />
+  <node id='-26235' action='modify' lat='52.14046166874' lon='20.79544543147' />
+  <node id='-26236' action='modify' lat='52.13908546922' lon='20.79101442218' />
+  <node id='-26237' action='modify' lat='52.13826894796' lon='20.78904031634' />
+  <node id='-26238' action='modify' lat='52.13570075936' lon='20.78332184672' />
+  <node id='-26239' action='modify' lat='52.13165720851' lon='20.77430962443' />
+  <node id='-26240' action='modify' lat='52.12844317994' lon='20.76718567729' />
+  <node id='-26241' action='modify' lat='52.1274288687' lon='20.76492189288' />
+  <node id='-26242' action='modify' lat='52.12692829101' lon='20.7635593307' />
+  <node id='-26243' action='modify' lat='52.12653309412' lon='20.76226114154' />
+  <node id='-26244' action='modify' lat='52.12632890769' lon='20.76138137698' />
+  <node id='-26245' action='modify' lat='52.12597322586' lon='20.75916050792' />
+  <node id='-26246' action='modify' lat='52.12481394687' lon='20.74819563746' />
+  <node id='-26247' action='modify' lat='52.12374026955' lon='20.73807834506' />
+  <node id='-26248' action='modify' lat='52.12238331519' lon='20.72530030131' />
+  <node id='-26249' action='modify' lat='52.12116465591' lon='20.71382044673' />
+  <node id='-26250' action='modify' lat='52.12091433259' lon='20.71225403666' />
+  <node id='-26251' action='modify' lat='52.12061130773' lon='20.71091293216' />
+  <node id='-26252' action='modify' lat='52.12026216784' lon='20.70973276019'>
+    <tag k='note' v='deliberately disconnected to check error handling' />
+  </node>
+  <node id='-26253' action='modify' lat='52.11953752915' lon='20.70793031573' />
+  <node id='-26254' action='modify' lat='52.11866135937' lon='20.70632099032' />
+  <node id='-26255' action='modify' lat='52.11780493617' lon='20.70513008952' />
+  <node id='-26256' action='modify' lat='52.11683649934' lon='20.70405720592' />
+  <node id='-26257' action='modify' lat='52.11349621907' lon='20.70067762256' />
+  <node id='-26258' action='modify' lat='52.11082776803' lon='20.6979524982' />
+  <node id='-26259' action='modify' lat='52.11008320874' lon='20.69699763179' />
+  <node id='-26260' action='modify' lat='52.10940452883' lon='20.69568871379' />
+  <node id='-26261' action='modify' lat='52.10889057018' lon='20.69406865954' />
+  <node id='-26262' action='modify' lat='52.10772425742' lon='20.68924068332' />
+  <node id='-26263' action='modify' lat='52.10502910163' lon='20.67827581286' />
+  <node id='-26264' action='modify' lat='52.10141114255' lon='20.66352366328' />
+  <node id='-26265' action='modify' lat='52.1008839109' lon='20.66132425189' />
+  <node id='-26266' action='modify' lat='52.10071255927' lon='20.65967201114' />
+  <node id='-26267' action='modify' lat='52.10074551156' lon='20.65833090663' />
+  <node id='-26268' action='modify' lat='52.10091686306' lon='20.65693615794' />
+  <node id='-26269' action='modify' lat='52.10130569672' lon='20.65550922275' />
+  <node id='-26270' action='modify' lat='52.10276214521' lon='20.65108894229' />
+  <node id='-26271' action='modify' lat='52.10425149584' lon='20.64649700046' />
+  <node id='-26272' action='modify' lat='52.10467324982' lon='20.64465164065' />
+  <node id='-26273' action='modify' lat='52.1047589181' lon='20.64283846736' />
+  <node id='-26274' action='modify' lat='52.10463371055' lon='20.64127205729' />
+  <node id='-26275' action='modify' lat='52.10431739516' lon='20.63989876628' />
+  <node id='-26276' action='modify' lat='52.10331571497' lon='20.63674448848' />
+  <node id='-26277' action='modify' lat='52.10187246514' lon='20.63213108897' />
+  <node id='-26278' action='modify' lat='52.10120684103' lon='20.63024281383' />
+  <node id='-26279' action='modify' lat='52.10062688321' lon='20.62840818286' />
+  <way id='-581' action='modify'>
+    <nd ref='-26136' />
+    <nd ref='-26138' />
+    <nd ref='-26139' />
+    <nd ref='-26140' />
+    <nd ref='-26141' />
+    <nd ref='-26142' />
+    <nd ref='-26143' />
+    <nd ref='-26144' />
+    <nd ref='-26145' />
+    <nd ref='-26146' />
+    <nd ref='-26147' />
+    <nd ref='-26148' />
+    <nd ref='-26149' />
+    <nd ref='-26150' />
+    <nd ref='-26151' />
+    <nd ref='-26152' />
+    <nd ref='-26153' />
+    <nd ref='-26154' />
+    <nd ref='-26155' />
+    <nd ref='-26156' />
+    <nd ref='-26157' />
+    <nd ref='-26158' />
+    <nd ref='-26159' />
+    <nd ref='-26160' />
+    <nd ref='-26161' />
+    <nd ref='-26162' />
+    <nd ref='-26163' />
+    <nd ref='-26164' />
+    <nd ref='-26165' />
+    <nd ref='-26166' />
+    <nd ref='-26167' />
+    <nd ref='-26168' />
+    <nd ref='-26169' />
+    <nd ref='-26170' />
+    <nd ref='-26171' />
+    <nd ref='-26172' />
+    <nd ref='-26173' />
+    <nd ref='-26174' />
+    <nd ref='-26175' />
+    <nd ref='-26176' />
+    <nd ref='-26177' />
+    <nd ref='-26178' />
+    <nd ref='-26179' />
+    <nd ref='-26180' />
+    <nd ref='-26181' />
+    <nd ref='-26182' />
+    <nd ref='-26183' />
+    <nd ref='-26184' />
+    <nd ref='-26185' />
+    <nd ref='-26186' />
+    <nd ref='-26187' />
+    <nd ref='-26188' />
+    <nd ref='-26189' />
+    <nd ref='-26190' />
+    <nd ref='-26191' />
+    <nd ref='-26192' />
+    <nd ref='-26193' />
+    <nd ref='-26194' />
+    <nd ref='-26195' />
+    <nd ref='-26196' />
+    <nd ref='-26197' />
+    <nd ref='-26198' />
+    <nd ref='-26199' />
+    <nd ref='-26200' />
+    <nd ref='-26201' />
+    <nd ref='-26202' />
+    <nd ref='-26203' />
+    <nd ref='-26204' />
+    <nd ref='-26205' />
+    <nd ref='-26206' />
+    <nd ref='-26207' />
+    <nd ref='-26208' />
+    <nd ref='-26209' />
+    <nd ref='-26210' />
+    <nd ref='-26211' />
+    <nd ref='-26212' />
+    <nd ref='-26213' />
+    <nd ref='-26214' />
+    <nd ref='-26215' />
+    <nd ref='-26216' />
+    <nd ref='-26217' />
+    <nd ref='-26218' />
+    <nd ref='-26219' />
+    <nd ref='-26220' />
+    <nd ref='-26221' />
+    <nd ref='-26222' />
+    <nd ref='-26223' />
+    <nd ref='-26224' />
+    <nd ref='-26225' />
+    <nd ref='-26226' />
+    <nd ref='-26227' />
+    <nd ref='-26228' />
+    <nd ref='-26229' />
+    <nd ref='-26230' />
+    <nd ref='-26231' />
+    <nd ref='-26232' />
+    <nd ref='-26233' />
+    <nd ref='-26234' />
+    <nd ref='-26235' />
+    <nd ref='-26236' />
+    <nd ref='-26237' />
+    <nd ref='-26238' />
+    <nd ref='-26239' />
+    <nd ref='-26240' />
+    <nd ref='-26241' />
+    <nd ref='-26242' />
+    <nd ref='-26243' />
+    <nd ref='-26244' />
+    <nd ref='-26245' />
+    <nd ref='-26246' />
+    <nd ref='-26247' />
+    <nd ref='-26248' />
+    <nd ref='-26249' />
+    <nd ref='-26250' />
+    <nd ref='-26251' />
+    <tag k='railway' v='rail' />
+  </way>
+  <way id='-794' action='modify'>
+    <nd ref='-26252' />
+    <nd ref='-26253' />
+    <nd ref='-26254' />
+    <nd ref='-26255' />
+    <nd ref='-26256' />
+    <nd ref='-26257' />
+    <nd ref='-26258' />
+    <nd ref='-26259' />
+    <nd ref='-26260' />
+    <nd ref='-26261' />
+    <nd ref='-26262' />
+    <nd ref='-26263' />
+    <nd ref='-26264' />
+    <nd ref='-26265' />
+    <nd ref='-26266' />
+    <nd ref='-26267' />
+    <nd ref='-26268' />
+    <nd ref='-26269' />
+    <nd ref='-26270' />
+    <nd ref='-26271' />
+    <nd ref='-26272' />
+    <nd ref='-26273' />
+    <nd ref='-26274' />
+    <nd ref='-26275' />
+    <nd ref='-26276' />
+    <nd ref='-26277' />
+    <nd ref='-26278' />
+    <nd ref='-26279' />
+    <tag k='railway' v='rail' />
+  </way>
+</osm>

--- a/tests/tasks/test_generate_shapes.py
+++ b/tests/tasks/test_generate_shapes.py
@@ -1,0 +1,367 @@
+# © Copyright 2026 Mikołaj Kuranowski
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, cast
+from unittest import TestCase
+from unittest.mock import Mock
+
+from routx.wrapper import Graph
+
+from impuls import selector
+from impuls.model import Route
+from impuls.resource import LocalResource
+from impuls.task import TaskRuntime
+from impuls.tasks.generate_shapes import (
+    ErrorLogger,
+    FallbackPolicy,
+    GeneratedShape,
+    GenerateShapes,
+    GeoJSONErrorWriter,
+    LegContext,
+    LegPlanner,
+    ShapePoint,
+    ShapeValidator,
+    StopSnapper,
+    StraightLineSubstitute,
+    Waypoint,
+)
+from impuls.tools.testing_mocks import MockFile
+
+from .template_testcase import AbstractTestTask
+
+FIXTURES = Path(__file__).with_name("fixtures")
+
+
+class MockStopSnapper(StopSnapper):
+    def snap(self, pt: Waypoint) -> int:
+        return {
+            "A": 10,
+            "B": 20,
+            "C": 30,
+        }.get(pt.cache_key(), 0)
+
+
+class TestHelpers(TestCase):
+    def test_generated_shape_append_leg(self) -> None:
+        shape = GeneratedShape()
+        shape.append_leg(
+            LegContext(Waypoint(("A", 0), 0.0, 0.0), Waypoint(("B", 1), 1.0, 1.0)),
+            [
+                (0.0, 0.0, 0.0),
+                (0.2, 0.5, 1.0),
+                (0.7, 0.5, 2.0),
+                (1.0, 1.0, 3.0),
+            ],
+        )
+        shape.append_leg(
+            LegContext(Waypoint(("B", 1), 1.0, 1.0), Waypoint(("C", 2), 2.0, 2.0)),
+            [
+                (1.0, 1.0, 0.0),
+                (1.5, 1.3, 0.3),
+                (1.5, 1.6, 0.6),
+                (2.0, 2.0, 0.9),
+            ],
+        )
+
+        self.assertListEqual(
+            shape.points,
+            [
+                (0.0, 0.0, 0.0),
+                (0.2, 0.5, 1.0),
+                (0.7, 0.5, 2.0),
+                (1.0, 1.0, 3.0),
+                (1.5, 1.3, 3.3),
+                (1.5, 1.6, 3.6),
+                (2.0, 2.0, 3.9),
+            ],
+        )
+
+        self.assertDictEqual(shape.distances, {0: 0.0, 1: 3.0, 2: 3.9})
+
+    def test_generated_shape_round(self) -> None:
+        shape = GeneratedShape(
+            points=[
+                (0.0, 0.0, 0.0),
+                (0.21328, 0.59317, 0.3412),
+                (0.75497, 0.52539, 0.7882),
+                (1.12102, 1.12347, 1.0126),
+            ],
+            distances={0: 0.0, 1: 0.5123, 2: 1.0126},
+        )
+        shape.round(coord_precision=2, dist_precision=1)
+
+        self.assertListEqual(
+            shape.points,
+            [
+                (0.0, 0.0, 0.0),
+                (0.21, 0.59, 0.3),
+                (0.75, 0.53, 0.8),
+                (1.12, 1.12, 1.0),
+            ],
+        )
+
+        self.assertDictEqual(shape.distances, {0: 0.0, 1: 0.5, 2: 1.0})
+
+    def test_distance_limited_stop_snapper(self) -> None:
+        s = MockStopSnapper().distance_limited(lambda _: (0.0, 0.0), max_distance_m=100.0)
+        self.assertEqual(s.snap(Waypoint("A", 0.0001, 0.0001)), 10)
+        self.assertEqual(s.snap(Waypoint("A", 0.1, 0.1)), 0)
+
+    def test_cached_stop_snapper(self) -> None:
+        upper = MockStopSnapper()
+        upper.snap = Mock(wraps=upper.snap)
+
+        s = upper.cached()
+        self.assertDictEqual(s.cache, {})
+
+        self.assertEqual(s.snap(Waypoint("A", 0.0001, 0.0001)), 10)
+        self.assertEqual(s.snap(Waypoint("Z", 1.1, 1.1)), 0)
+        self.assertDictEqual(s.cache, {"A": 10, "Z": 0})
+        self.assertEqual(upper.snap.call_count, 2)
+
+        self.assertEqual(s.snap(Waypoint("A", 1.1, 1.1)), 10)
+        self.assertEqual(s.snap(Waypoint("Z", 0.0001, 0.0001)), 0)
+        self.assertDictEqual(s.cache, {"A": 10, "Z": 0})
+        self.assertEqual(upper.snap.call_count, 2)
+
+    def test_error_logger(self) -> None:
+        l = ErrorLogger()
+
+        with self.assertLogs(l.logger, logging.WARNING) as log_ctx:
+            l.on_error(
+                LegContext(Waypoint(("A", 1), 0.0, 0.0), Waypoint(("B", 2), 1.0, 1.0, 42)),
+                "unsnapped_waypoint",
+                [],
+            )
+
+            l.on_error(
+                LegContext(Waypoint(("B", 2), 0.0, 0.0, 37), Waypoint(("C", 3), 2.0, 2.0, 32)),
+                {"error": "straight_line", "fit": 0.0001},
+                [(1.0, 1.0, 0.0), (1.5, 1.3, 0.3), (1.5, 1.6, 0.6), (2.0, 2.0, 0.9)],
+            )
+
+        self.assertEqual(len(log_ctx.records), 2)
+        self.assertEqual(
+            log_ctx.records[0].message,
+            "Shape from A to B failed to generate: unsnapped_waypoint",
+        )
+        self.assertEqual(
+            log_ctx.records[1].message,
+            "Shape from B to C failed to generate: {'error': 'straight_line', 'fit': 0.0001}",
+        )
+
+    def test_geojson_error_writer(self) -> None:
+        with MockFile(directory=True) as temp_dir:
+            l = GeoJSONErrorWriter(temp_dir)
+            l.on_error(
+                LegContext(Waypoint(("A", 1), 0.0, 0.0), Waypoint(("B", 2), 1.0, 1.0, 42)),
+                "unsnapped_waypoint",
+                [],
+            )
+            l.on_error(
+                LegContext(Waypoint(("B", 2), 0.0, 0.0, 37), Waypoint(("C", 3), 2.0, 2.0, 32)),
+                {"error": "straight_line", "fit": 0.0001},
+                [(1.0, 1.0, 0.0), (1.5, 1.3, 0.3), (1.5, 1.6, 0.6), (2.0, 2.0, 0.9)],
+            )
+
+            self.assertSetEqual(
+                {i.name for i in temp_dir.iterdir()},
+                {"A__B.geojson", "B__C.geojson"},
+            )
+
+            with (temp_dir / "A__B.geojson").open("rb") as f:
+                self.assertDictEqual(
+                    json.load(f),
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "error": "unsnapped_waypoint",
+                            "start_stop_id": "A",
+                            "start_node_id": 0,
+                            "end_stop_id": "B",
+                            "end_node_id": 42,
+                        },
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [],
+                        },
+                    },
+                )
+
+            with (temp_dir / "B__C.geojson").open("rb") as f:
+                self.assertDictEqual(
+                    json.load(f),
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "error": {"error": "straight_line", "fit": 0.0001},
+                            "start_stop_id": "B",
+                            "start_node_id": 37,
+                            "end_stop_id": "C",
+                            "end_node_id": 32,
+                        },
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [[1.0, 1.0], [1.3, 1.5], [1.6, 1.5], [2.0, 2.0]],
+                        },
+                    },
+                )
+
+    def test_straight_line_substitute(self) -> None:
+        s = StraightLineSubstitute()
+        leg = s.substitute_leg(
+            LegContext(
+                Waypoint(("A", 1), 0.001, 0.002, 67),
+                Waypoint(("B", 2), 0.0025, 0.0029, 69),
+            ),
+            "no_route",
+        )
+        assert isinstance(leg, list)
+        self.assertListEqual(
+            leg,
+            [
+                (0.001, 0.002, 0.0),
+                (0.0025, 0.0029, 0.19451194911007125),
+            ],
+        )
+
+    def test_leg_planner(self) -> None:
+        start = Waypoint(("A", 0), 0.0, 0.0)
+        end = Waypoint(("B", 1), 1.0, 1.0)
+        legs = list(LegPlanner().plan_waypoints(start, end))
+        self.assertListEqual(
+            legs,
+            [LegContext(Waypoint(("A", 0), 0.0, 0.0), Waypoint(("B", 1), 1.0, 1.0))],
+        )
+
+
+class MockShapeValidator(ShapeValidator):
+    def validate_leg(self, ctx: LegContext, points: Sequence[ShapePoint]) -> Any:
+        if ctx.end.cache_key() == "wsrod":
+            return "no_warszawa_srodmiescie_wkd"
+        return None
+
+
+class FullGenerateShapes(GenerateShapes):
+    def create_fallback_policy(self, r: TaskRuntime, graph: Graph) -> FallbackPolicy:
+        return StraightLineSubstitute()
+
+    def create_shape_validator(self, r: TaskRuntime, graph: Graph) -> ShapeValidator:
+        return MockShapeValidator()
+
+
+class TestGenerateShapes(AbstractTestTask.Template):
+    resources = {  # noqa: RUF012
+        "wkd-shape-graph.osm": LocalResource(FIXTURES / "wkd-shape-graph.osm"),
+    }
+
+    def setUp(self) -> None:
+        super().setUp()
+        with self.runtime.db.transaction():
+            self.runtime.db.raw_execute("UPDATE trips SET shape_id = NULL")
+            self.runtime.db.raw_execute("DELETE FROM shapes")
+
+    def test(self) -> None:
+        db = self.runtime.db
+        task = FullGenerateShapes(
+            osm_resource="wkd-shape-graph.osm",
+            routes=selector.Routes(type=Route.Type.RAIL),
+            id_prefix="generated_",
+        )
+
+        with self.assertLogs(task.logger, logging.WARNING) as log_ctx:
+            task.execute(self.runtime)
+
+        # Check that no shapes were generated for buses
+        self.assertSetEqual(
+            {
+                cast(str | None, i[0])
+                for i in db.raw_execute(
+                    "SELECT shape_id FROM trips JOIN routes USING (route_id) WHERE type = 3"
+                )
+            },
+            {None},
+        )
+
+        # There should be 4 unique shapes:
+        # | Example Trip | From                   | To                     |
+        # |--------------|------------------------|------------------------|
+        # | C-303        | W-wa Śródmieście WKD   | Podkowa Leśna Główna   |
+        # | C-105        | W-wa Śródmieście WKD   | Grodzisk Maz. Radońska |
+        # | C-104        | Grodzisk Maz. Radońska | W-wa Śródmieście WKD   |
+        # | C-312        | Podkowa Leśna Główna   | W-wa Śródmieście WKD   |
+        self.assertEqual(
+            cast(int, db.raw_execute("SELECT COUNT(*) FROM shapes").one_must("count")[0]),
+            4,
+        )
+
+        # With 2 deliberate errors:
+        # - no_route between Podkowa Leśna Zachodnia and Kazimierówka
+        # - no_warszawa_srodmiescie_wkd from W-wa Ochota WKD to W-wa Śródmieście WKD
+        self.assertSetEqual(
+            {i.message for i in log_ctx.records},
+            {
+                "Shape from kazim to plzac failed to generate: no_route",
+                "Shape from plzac to kazim failed to generate: no_route",
+                "Shape from wocho to wsrod failed to generate: no_warszawa_srodmiescie_wkd",
+            },
+        )
+
+        # Check the shape from Grodzisk to Warszawa
+
+        # fmt: off
+        shape_id = (
+            db
+            .raw_execute("SELECT shape_id FROM trips WHERE trip_id = 'C-104'")
+            .one_must("C-104 trip missing")
+            [0]
+        )
+        # fmt: on
+
+        shape_points = [
+            cast(tuple[float, float, float], i)
+            for i in db.raw_execute(
+                "SELECT lat, lon, shape_dist_traveled FROM shape_points "
+                "WHERE shape_id = ? ORDER BY sequence",
+                (shape_id,),
+            )
+        ]
+        self.assertEqual(len(shape_points), 124)
+        self.assertListEqual(
+            shape_points[:6],
+            [
+                (52.100628, 20.628408, 0.0),
+                (52.101208, 20.630243, 0.141),
+                (52.101871, 20.632132, 0.29),
+                (52.103317, 20.636744, 0.643),
+                (52.104317, 20.639898, 0.886),
+                (52.104633, 20.641272, 0.986),
+            ],
+        )
+        self.assertListEqual(
+            shape_points[-6:],
+            [
+                (52.221989, 20.975174, 30.509),
+                (52.222267, 20.976322, 30.594),
+                (52.222633, 20.977589, 30.689),
+                (52.224277, 20.984509, 31.194),
+                (52.225414, 20.989477, 31.556),
+                (52.227686, 21.000404, 32.333),
+            ],
+        )
+
+        shape_distances = {
+            cast(str, i[0]): cast(float, i[1])
+            for i in db.raw_execute(
+                "SELECT stop_id, shape_dist_traveled FROM stop_times WHERE trip_id = 'C-104'"
+            )
+        }
+        self.assertAlmostEqual(shape_distances["gmrad"], 0.0)
+        self.assertAlmostEqual(shape_distances["gmjor"], 0.643)
+        self.assertAlmostEqual(shape_distances["plzac"], 6.621)
+        self.assertAlmostEqual(shape_distances["wocho"], 31.556)
+        self.assertAlmostEqual(shape_distances["wsrod"], 32.333)


### PR DESCRIPTION
This PR introduces a task to generate shapes based on OSM data. The design is supposed to be simple enough to be able to simply add a `GenerateShapes(osm_resource="foo.osm", routes=selector.Routes(type=Route.Type.BUS))` into a pipeline and get shapes; while also being extensible enough to support weird edge cases and improvements found in users of Impuls, like [waypoints between stops](https://github.com/MKuranowski/PolishTrainsGTFS/blob/fa793e7c0ea9889217a6dc7cfbb8b0346c98a4ba/polish_trains_gtfs/static/generate_shapes/matcher.py#L108), [using OSM tags for better stop snapping](https://github.com/MKuranowski/WarsawGTFS/blob/52119658283627209ec6729bd35accdf554c9368/warsaw_gtfs/generate_shapes/task.py#L167), [dumping errors as files](https://github.com/MKuranowski/WarsawGTFS/blob/52119658283627209ec6729bd35accdf554c9368/warsaw_gtfs/generate_shapes/generator.py#L254) or [using different routing profiles for different routes](https://github.com/MKuranowski/TokyoGTFS/blob/6a1ecc0cb9f86e9f85abe5f5c82d6f82ee79d5a0/tokyo_gtfs/rail/generate_shapes.py#L148).

Closes #16.

TODO:
- [x] Design
- [x] Implement
- [x] Test
- [x] Document (check that the documentation looks good in Shpinx)